### PR TITLE
Implemented extended timer

### DIFF
--- a/src/cm_time/main.py
+++ b/src/cm_time/main.py
@@ -83,13 +83,13 @@ class timer(ContextDecorator):
 
     @property
     def elapsed(self) -> float:
-        """Elapsed time in seconds."""
-        return self._elapsed
+        """Recent elapsed time in seconds."""
+        return self._intervals[-1] if self._intervals else None
 
     @property
-    def recent(self) -> float | None:
+    def total_elapsed(self) -> float | None:
         """Elapsed time in seconds."""
-        return self._intervals[-1] if self._intervals else None
+        return self._elapsed
 
     @property
     def intervals(self) -> list[float]:

--- a/src/cm_time/main.py
+++ b/src/cm_time/main.py
@@ -82,12 +82,12 @@ class timer(ContextDecorator):
             self._logger.log(self._level, self._message.format(_elapsed))
 
     @property
-    def elapsed(self) -> float:
+    def elapsed(self) -> float | None:
         """Recent elapsed time in seconds."""
         return self._intervals[-1] if self._intervals else None
 
     @property
-    def total_elapsed(self) -> float | None:
+    def total_elapsed(self) -> float:
         """Elapsed time in seconds."""
         return self._elapsed
 
@@ -99,6 +99,7 @@ class timer(ContextDecorator):
     def clear_intervals(self) -> None:
         """Clears all the stored intervals."""
         self._intervals.clear()
+        self._elapsed = 0.0
 
 
 _TParams = ParamSpec("_TParams")


### PR DESCRIPTION
Implemented a new feature which simplifies timing and measurement tasks by allowing the use of a single timer to gauge multiple context blocks—both collectively and individually.

```py
>>> from cm_time import timer
>>> import requests

# Create a timer
>>> request_timer = timer()

# Start timing the first context block
>>> with request_timer:
...     requests.get('https://www.google.com')

# Get elapsed time for the first block
>>> request_timer.elapsed
0.6406652669975301

# Start timing the second context block
>>> with request_timer:
...     requests.get('https://www.google.com')

# Get elapsed time for the second block
>>> request_timer.elapsed
0.7218053240067093

# Get the total elapsed time
>>> request_timer.total_elapsed
1.3624705910042394

# Get individual interval times
>>> request_timer.intervals
[0.6406652669975301, 0.7218053240067093]
```
If the user wanted to reset and use the same timer
```py
# Continuation from previous example
>>> request_timer.intervals
[0.6406652669975301, 0.7218053240067093]

# Clear intervals
>>> request_timer.clear_intervals()

# Start timing a new context block
>>> with request_timer:
...     requests.get('https://www.google.com')

# Get elapsed time for the new block
>>> request_timer.elapsed
0.5754496199951973

# Get the total elapsed time for the new block
>>> request_timer.total_elapsed
0.5754496199951973

# Get individual interval times for the new block
>>> request_timer.intervals
[0.5754496199951973]
```